### PR TITLE
feat: added Models page to header and removed from settings

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,13 @@
   import { Input } from "$lib/components/ui/input";
   import { Button } from "$lib/components/ui/button";
   import { Label } from "$lib/components/ui/label";
-  import { Settings, Home, FileText, PlayCircle } from "lucide-svelte";
+  import {
+    Settings,
+    Home,
+    FileText,
+    PlayCircle,
+    Database,
+  } from "lucide-svelte";
   import { Textarea } from "$lib/components/ui/textarea";
 
   // custom svelte components
@@ -76,6 +82,9 @@
     <nav class="flex space-x-4">
       <a href="/patterns" class="text-gray-600 hover:text-gray-900"
         ><FileText size={24} /></a
+      >
+      <a href="/models" class="text-gray-600 hover:text-gray-900"
+        ><Database size={24} /></a
       >
       <a href="/settings" class="text-gray-600 hover:text-gray-900"
         ><Settings size={24} /></a

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import ModelsTable from "$lib/components/ModelsTable.svelte";
+</script>
+
+<div class="container py-8">
+  <h1 class="text-3xl font-bold mb-6">Models</h1>
+  <ModelsTable />
+</div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,7 +7,7 @@
   import { PlayCircle } from "lucide-svelte";
 
   // tables
-  import ModelsTable from "$lib/components/ModelsTable.svelte";
+  // import ModelsTable from "$lib/components/ModelsTable.svelte";
   import SecretsTable from "$lib/components/ApiKeysTable.svelte";
   import BaseUrlTable from "$lib/components/BaseUrlTable.svelte";
 
@@ -36,7 +36,6 @@
   <Tabs.Root value="general">
     <Tabs.List>
       <Tabs.Trigger value="general">General</Tabs.Trigger>
-      <Tabs.Trigger value="models">Models</Tabs.Trigger>
       <Tabs.Trigger value="secrets">API Keys</Tabs.Trigger>
       <Tabs.Trigger value="base-urls">Base URLs</Tabs.Trigger>
     </Tabs.List>
@@ -75,11 +74,6 @@
           <Switch id="notifications" bind:checked={notifications} />
           <Label for="notifications">Enable Notifications</Label>
         </div>
-      </div>
-    </Tabs.Content>
-    <Tabs.Content value="models">
-      <div class="mt-4">
-        <ModelsTable />
       </div>
     </Tabs.Content>
     <Tabs.Content value="secrets">


### PR DESCRIPTION
Added a Database icon to the navigation bar and created the Models page with a table to display models. Removed the Models tab from the Settings page.