### PR TITLE
Make header appear everywhere

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,15 +1,22 @@
 <script>
   import "../app.css";
   import BackButton from "../lib/components/BackButton.svelte";
+  import Header from "./Header.svelte";
   import { Toaster } from "$lib/components/ui/sonner";
+  import SettingsDrawer from "./settings/+page.svelte";
+  import { settingsOpen } from "$lib/stores/settings";
 </script>
 
 <Toaster />
-<!-- <slot></slot>-->
 
-<header>
-  <BackButton />
-</header>
+<div class="flex flex-col h-screen">
+  <Header />
+  <main class="flex-grow">
+    <slot />
+  </main>
+</div>
+
+<SettingsDrawer />
 
 <main>
   <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,8 +2,7 @@
   // svelte stores
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
-  import { writable } from "svelte/store";
-  import type { Writable } from "svelte/store";
+  import { writable, type Writable } from "svelte/store";
 
   // svelte components
   import { Input } from "$lib/components/ui/input";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,32 +74,7 @@
 </script>
 
 <div class="flex flex-col h-screen">
-  <header class="flex justify-between items-center p-4 border-b">
-    <div class="flex items-center">
-      <!-- TODO add fabric logo -->
-      <!-- <img src="/logo.png" alt="Fabric Logo" class="h-8 w-8 mr-2" /> -->
-      <h1 class="text-2xl font-bold">Fabric</h1>
-    </div>
-    <nav class="flex space-x-4">
-      <a href="/patterns" class="text-gray-600 hover:text-gray-900"
-        ><FileText size={24} /></a
-      >
-      <a href="/models" class="text-gray-600 hover:text-gray-900"
-        ><Database size={24} /></a
-      >
-      <!-- <a href="/settings" class="text-gray-600 hover:text-gray-900"
-        ><Settings size={24} /></a
-      > -->
-      <button
-        class="text-gray-600 hover:text-gray-900"
-        on:click={() => ($settingsOpen = true)}
-      >
-        <Settings size={24} />
-      </button>
-    </nav>
-  </header>
-
-  <SettingsDrawer />
+  <!-- <SettingsDrawer /> -->
 
   <main class="flex-grow p-6">
     <div class="max-w-3xl mx-auto">

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { Settings, FileText, Database, Home } from "lucide-svelte";
+  import { settingsOpen } from "$lib/stores/settings";
+</script>
+
+<header class="flex justify-between items-center p-4 border-b">
+  <!-- Left section -->
+  <div class="flex items-center w-1/4">
+    <h1 class="text-2xl font-bold">Fabric</h1>
+  </div>
+
+  <!-- Center section -->
+  <nav class="flex justify-center space-x-8 flex-1">
+    <a href="/" class="text-gray-600 hover:text-gray-900"><Home size={24} /></a>
+    <a href="/patterns" class="text-gray-600 hover:text-gray-900"
+      ><FileText size={24} /></a
+    >
+    <a href="/models" class="text-gray-600 hover:text-gray-900"
+      ><Database size={24} /></a
+    >
+  </nav>
+
+  <!-- Right section -->
+  <div class="flex justify-end w-1/4">
+    <button
+      class="text-gray-600 hover:text-gray-900"
+      on:click={() => ($settingsOpen = true)}
+    >
+      <Settings size={24} />
+    </button>
+  </div>
+</header>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,12 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
+    // Add these configurations for Tauri
+    prerender: {
+      default: true
+    },
+    // Prevent SvelteKit from handling static assets that Tauri will handle
+    inlineStyleThreshold: Infinity
   },
 };
 


### PR DESCRIPTION
This pull request includes changes to ensure that the header appears consistently throughout the application. 

Changes in this PR:
- Added configurations for Tauri in SvelteKit adapter
- Combined import statements for Svelte stores in page component
- Updated the header layout for the fabric app.