### PR TITLE
Add dropdown for filtering by vendor in models table

### DIFF
--- a/src-tauri/src/fabric/settings/vendors.rs
+++ b/src-tauri/src/fabric/settings/vendors.rs
@@ -34,7 +34,5 @@ pub fn get_vendors(_app_handle: tauri::AppHandle) -> Result<Vec<String>, String>
         .map(|line| line.trim().to_string())
         .collect();
 
-    println!("vendors: {:?}", vendors);
-
     Ok(vendors)
 }

--- a/src/routes/models/table/table.svelte
+++ b/src/routes/models/table/table.svelte
@@ -17,6 +17,7 @@
   import * as Table from "$lib/components/ui/table";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
+  import * as Select from "$lib/components/ui/select";
 
   // svelte
   import { onMount } from "svelte";
@@ -33,8 +34,9 @@
     name: string;
     provider: string;
   }
-
+  let originalModelsData: Model[] = [];
   let modelsData: Writable<Model[]> = writable([]);
+  let selectedVendor = { value: "all", label: "All Vendors" };
 
   const table = createTable(modelsData, {
     sort: addSortBy({ disableMultiSort: true }),
@@ -44,6 +46,17 @@
     }),
     page: addPagination({ initialPageSize: 10 }),
   });
+
+  // Add this to track unique vendors and filter data
+  $: vendors = [...new Set($modelsData.map((model) => model.provider))];
+  $: {
+    const filteredData = originalModelsData.filter(
+      (model) =>
+        selectedVendor.value === "all" ||
+        model.provider === selectedVendor.value
+    );
+    modelsData.set(filteredData);
+  }
 
   const columns = table.createColumns([
     table.column({
@@ -123,7 +136,7 @@
           );
         }
       }
-
+      originalModelsData = formattedModels;
       modelsData.set(formattedModels);
     } catch (err) {
       console.error("Failed to fetch models:", err);
@@ -148,6 +161,17 @@
       type="text"
       bind:value={$filterValue}
     />
+    <Select.Root bind:selected={selectedVendor}>
+      <Select.Trigger class="w-[180px]">
+        <Select.Value placeholder="Select Vendor" />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="all">All Vendors</Select.Item>
+        {#each vendors as vendor}
+          <Select.Item value={vendor}>{vendor}</Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
   </div>
 
   <!-- table -->


### PR DESCRIPTION
Add a dropdown menu to enable filtering by vendor in the models table. This feature adds the ability to track unique vendors and filter the data based on the selected vendor. Additionally, it includes a code refactor to remove unnecessary print statements in the `get_vendors` function.