### PR TITLE
ci: Update GitHub token in Todoist sync workflow

### DIFF
--- a/.github/workflows/todoist-sync.yml
+++ b/.github/workflows/todoist-sync.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Sync Issues to Todoist
         uses: simenandre/todoist-action@v1.2.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           todoist-token: ${{ secrets.TODOIST_API_KEY }}
           query: 
             updated:>2024-01-01 archived:false sort:updated-desc


### PR DESCRIPTION
Update the GitHub token in the Todoist sync workflow to use the PAT
secret for enhanced security.