### PR TITLE
feat: Add sessions module with session management commands

### DIFF
--- a/src-tauri/src/fabric/mod.rs
+++ b/src-tauri/src/fabric/mod.rs
@@ -19,8 +19,6 @@ pub use install::install_fabric;
 
 pub mod settings;
 pub use settings::*;
-// pub use settings::models::{
-//     get_frequency_penalty, get_model, get_models, get_presence_penalty, get_temperature, get_top_p,
-//     set_default_model, set_frequency_penalty, set_model, set_presence_penalty, set_temperature,
-//     set_top_p,
-// };
+
+pub mod sessions;
+pub use sessions::*;

--- a/src-tauri/src/fabric/run.rs
+++ b/src-tauri/src/fabric/run.rs
@@ -3,6 +3,7 @@ use tauri::{AppHandle, Error, State};
 use tauri_plugin_shell::ShellExt;
 
 // TODO get the jina ai functions to work from the rust side
+// TODO change function to "run_fabric_pattern"
 #[tauri::command]
 pub async fn run_fabric_command(
     app: AppHandle,

--- a/src-tauri/src/fabric/run.rs
+++ b/src-tauri/src/fabric/run.rs
@@ -4,6 +4,7 @@ use tauri_plugin_shell::ShellExt;
 
 // TODO get the jina ai functions to work from the rust side
 // TODO change function to "run_fabric_pattern"
+// Issue URL: https://github.com/noamsiegel/fabric-app/issues/82
 #[tauri::command]
 pub async fn run_fabric_command(
     app: AppHandle,

--- a/src-tauri/src/fabric/sessions.rs
+++ b/src-tauri/src/fabric/sessions.rs
@@ -1,0 +1,87 @@
+use tauri::{Error, Manager};
+use tauri_plugin_shell::ShellExt;
+
+#[tauri::command]
+pub async fn set_session(app: tauri::AppHandle, session: String) -> Result<String, Error> {
+    let shell = app.shell();
+    let output = shell
+        .command("fabric")
+        .args(["--session", &session])
+        .output()
+        .await
+        .map_err(|_| Error::FailedToReceiveMessage)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(Error::FailedToReceiveMessage)
+    }
+}
+
+#[tauri::command]
+pub async fn list_sessions(app: tauri::AppHandle) -> Result<String, Error> {
+    let shell = app.shell();
+    let output = shell
+        .command("fabric")
+        .args(["-X"])
+        .output()
+        .await
+        .map_err(|_| Error::FailedToReceiveMessage)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(Error::FailedToReceiveMessage)
+    }
+}
+
+#[tauri::command]
+pub async fn output_session(app: tauri::AppHandle) -> Result<String, Error> {
+    let shell = app.shell();
+    let output = shell
+        .command("fabric")
+        .args(["--output-session"])
+        .output()
+        .await
+        .map_err(|_| Error::FailedToReceiveMessage)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(Error::FailedToReceiveMessage)
+    }
+}
+
+#[tauri::command]
+pub async fn wipe_session(app: tauri::AppHandle, session: String) -> Result<String, Error> {
+    let shell = app.shell();
+    let output = shell
+        .command("fabric")
+        .args(["-W", &session])
+        .output()
+        .await
+        .map_err(|_| Error::FailedToReceiveMessage)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(Error::FailedToReceiveMessage)
+    }
+}
+
+#[tauri::command]
+pub async fn print_session(app: tauri::AppHandle, session: String) -> Result<String, Error> {
+    let shell = app.shell();
+    let output = shell
+        .command("fabric")
+        .args(["--printsession", &session])
+        .output()
+        .await
+        .map_err(|_| Error::FailedToReceiveMessage)?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(Error::FailedToReceiveMessage)
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,10 @@ use crate::plugins::get_clipboard_contents;
 mod state;
 use crate::state::AppState;
 
+use crate::fabric::sessions::{
+    list_sessions, output_session, print_session, set_session, wipe_session,
+};
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -105,6 +109,12 @@ pub fn run() {
             get_models,
             get_model,
             set_model,
+            // sessions
+            list_sessions,
+            output_session,
+            set_session,
+            wipe_session,
+            print_session,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
- Add sessions module to handle session management commands
- Implement functions to set, list, output, wipe, and print sessions
- Commands interact with the "fabric" binary for session management