### PR TITLE
feat: add GitHub Actions workflow for publishing release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,40 @@
+name: 'publish'
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: install frontend dependencies
+        run: yarn install # or npm install
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__
+          releaseName: 'App v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false


### PR DESCRIPTION
Create a GitHub Actions workflow to automate the release 
process on the `release` branch. This workflow supports 
multiple platforms (macOS, Ubuntu, Windows) and sets up 
the environment by installing Node.js, Rust, and necessary 
dependencies. It also configures the Tauri action for 
releasing with a designated tag and name. These changes 
streamline the deployment process and ensure consistent 
releases across different platforms.