### PR TITLE
refactor: rename project from fabric-app to Fabric

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "Fabric"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
+ "tauri-plugin-os",
+ "tauri-plugin-shell",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,22 +1161,6 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
-]
-
-[[package]]
-name = "fabric-app"
-version = "0.1.0"
-dependencies = [
- "regex",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-clipboard-manager",
- "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-os",
- "tauri-plugin-shell",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fabric-app"
+name = "Fabric"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "fabric-app",
+  "productName": "Fabric",
   "version": "0.1.0",
   "identifier": "com.fabric-app.app",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "fabric-app",
+        "title": "Fabric",
         "width": 800,
         "height": 600
       }


### PR DESCRIPTION
Update project name in Cargo.toml, Cargo.lock, and 
tauri.conf.json to reflect the new branding. This 
change enhances clarity and aligns the project name 
with its intended identity.